### PR TITLE
Revert usage of `Mapping::take`

### DIFF
--- a/contracts/bulletin_board/lib.rs
+++ b/contracts/bulletin_board/lib.rs
@@ -384,10 +384,11 @@ mod bulletin_board {
             &mut self,
             caller: AccountId,
         ) -> Result<u32, BulletinBoardError> {
-            match self.id_map.take(caller) {
+            match self.id_map.get(caller) {
                 None => return Err(BulletinBoardError::BulletinNotFound),
                 Some(bulletin_id) => {
                     self.bulletin_map.remove(bulletin_id);
+                    self.id_map.remove(caller);
                     self.elements_count -= 1;
                     self.post_authors.retain(|author| author != &caller);
                     Ok(bulletin_id)


### PR DESCRIPTION
This doesn't work with current pallet-contract. Method exists in the API, was added to ink4 but is not available on the production chain.