### PR TITLE
Fix the deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,36 @@ This repository will serve dApp developers, interested in developing for Aleph Z
 
 ### Prerequisities
 
-1. `substrate-contracts-node` version [`v0.22.1`](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.22.1). Later releases are compatible with `pallet-contracts` version `0.9.34` which is not the same one as Aleph Zero Testnet.
-2. `cargo-contract` version [`2.0.0-beta.1`](https://github.com/paritytech/cargo-contract/releases/tag/v2.0.0-beta.1). Later releases are compatible with `pallet-contracts` version `0.9.34` which is not the same one as Aleph Zero Testnet.
+1. Rust in version 1.69.0 with the `nightly-2023-02-07` toolchain.
+2. `substrate-contracts-node` version [`v0.26.0`](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.26.0).
+3. `cargo-contract` version [`3.0.1`](https://github.com/paritytech/cargo-contract/releases/tag/v3.0.1).
+
+**To install Rust**, run:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+This will install `rustup`, the Rust version and toolchain management tool. Next, use it to install Rust and the appropriate toolchain:
+
+```bash
+rustup install 1.69.0
+rustup install nightly-2023-02-07-x86_64-unknown-linux-gnu
+```
+
+**To install the `substrate-contracts-node`**, simply download it from [the release page](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.26.0), unpack the archive and put the binary on your path (remember to reload the shell for this to take effect).
+
+**To install cargo contract**, run:
+```bash
+cargo install --force --locked cargo-contract --version 3.0.1
+```
+
+You can verify your versions using:
+```bash
+rustup show
+substrate-contracts-node --version
+cargo contract --version
+```
 
 ### Running chain
 
@@ -37,6 +65,12 @@ In the root directory, run `make setup`. This will:
 * instantiate them
 * record their addresses
 * update the addresses and contracts' metadata files in the frontend directory
+
+If you need to upload the contracts many times, you have two options:
+* run the `make chain-restart` command, which will remove the old contracts,
+* set the `BULLETIN_BOARD_VERSION` variable to different two-digit numbers with each run, which will allow you to upload different instances of the same contract.
+
+Option 1 is the recommended one for most use cases.
 
 ### Running the frontend
 

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -1,3 +1,3 @@
 build-all:
-	cargo contract build --release --manifest-path bulletin_board/Cargo.toml
-	cargo contract build --release --manifest-path highlighted_posts/Cargo.toml
+	cargo +nightly-2023-02-07 contract build --release --manifest-path highlighted_posts/Cargo.toml
+	cargo +nightly-2023-02-07 contract build --release --manifest-path bulletin_board/Cargo.toml

--- a/contracts/bulletin_board/Cargo.lock
+++ b/contracts/bulletin_board/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "cc"
@@ -119,6 +119,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +161,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -181,6 +216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,14 +290,14 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "ink"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b4fc39f3bcab7e042becf5c9dbbebc179fff64924025753a5fafa016e8576d"
+checksum = "311a988dada2242dc748834b86f330bb37ff25482ceef8767104f512a3c465a7"
 dependencies = [
  "derive_more",
  "ink_env",
@@ -264,18 +311,18 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121758652007d56209c7f79af5cc8562b7e869df7ebb72456da79f2a9e72aeea"
+checksum = "5cb3178f207f6a37c3512142c8c6c2561a2aac61d60baa934d08d1e55a67d4a8"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_codegen"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283b022679ef75898db5c28b89388412d93f91cea4f0b1443426901cb391b079"
+checksum = "f0b22c0517e5c249d7997cb20e7bd6fbf2076708d39e7b114465c2cb9c1d5c9c"
 dependencies = [
  "blake2",
  "derive_more",
@@ -292,14 +339,14 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "ink_engine"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daed9b710cba6f50f1fa0372a7e8a47a35624d84af4ef2c3a8d34d4e96202d1c"
+checksum = "3c9abc50b932893113e782761ac719c46214ecd10c423a3f626dce30a0c61b45"
 dependencies = [
  "blake2",
  "derive_more",
@@ -312,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41c6a3f4e740e27449f805ed47f536a35fb254ebcd03d2480014589331cda3e"
+checksum = "aef653137381ff5f37ce2ff9130d11dd1b25f6e9734d97d687c3b953dee4d14f"
 dependencies = [
  "arrayref",
  "blake2",
@@ -322,7 +369,6 @@ dependencies = [
  "derive_more",
  "ink_allocator",
  "ink_engine",
- "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "ink_storage_traits",
@@ -330,6 +376,8 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "rlibc",
+ "scale-decode",
+ "scale-encode",
  "scale-info",
  "secp256k1",
  "sha2",
@@ -339,23 +387,23 @@ dependencies = [
 
 [[package]]
 name = "ink_ir"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aeb30e90744ebf9cce7300a1d013ab91e1b84ebc9887ddabd9b7688c6ac20c1"
+checksum = "1bb9a2826cae9617d8ed2d547ed6e595deb334c1b69ff0a579abd86a76e48c30"
 dependencies = [
  "blake2",
  "either",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "ink_macro"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6642450e6169cfaf81717b1d62b2abae48a6b41d3f70f885b6aeff7bb14ea96b"
+checksum = "c0399b6423e892efb4d39eb76ed9286e4e93fab8141f89b4f4348ee77065b81d"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -363,15 +411,15 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "synstructure",
 ]
 
 [[package]]
 name = "ink_metadata"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfcfa666ada5729c7e4d3d986cd196365a2c469459fced4fa31dc6ad87c4d8f"
+checksum = "d5fb2b5ad83f725a6d0c8886ca737964d0013a193ca2d21c7e514fd427672416"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -383,31 +431,33 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050dcae91877df7def5fe4426df22c35d116bb24560e3e40d5650b09c7854061"
+checksum = "6a6f174d742ff929abe66716ad8159f324441b4ff5161a3b0e282f416afbbac1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_primitives"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b3f711d857d2de7c08158369cc32a762833ac211a00aac7931992094e25741"
+checksum = "14b4e4772e1b9384233103c1f488df9854d24b3c16168bcf23613b7d98fb363f"
 dependencies = [
  "derive_more",
  "ink_prelude",
  "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
  "scale-info",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "ink_storage"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2872a5ea4559433381b2d82b08b6acd33ce934b07a22ce951c6f00483680c950"
+checksum = "9a0f0858c90d5660dc6ec76d31388919a9609aab74723262ccf893d81aafd06c"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -423,16 +473,15 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "4.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c90e11b60233ae5ab877854739da2c380a337cb31b3900cb50328821c0381b6"
+checksum = "a4179f00b052e5955ab7535c1a69042a468771217e9db6a12de2cdbfcb03c861"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "parity-scale-codec",
  "scale-info",
- "syn",
 ]
 
 [[package]]
@@ -522,9 +571,9 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.1"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -536,14 +585,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -565,18 +614,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -631,10 +680,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
-name = "scale-info"
-version = "2.3.1"
+name = "scale-bits"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
+checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e5527e4b3bf079d4c0b2f253418598c380722ba37ef20fac9088081407f2b6"
+dependencies = [
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-decode-derive",
+ "scale-info",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-decode-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38741b2f78e4391b94eac6b102af0f6ea2b0f7fe65adb55d7f4004f507854db"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15546e5efbb45f0fc2291f7e202dee8623274c5d8bbfdf9c6886cc8b44a7ced3"
+dependencies = [
+ "parity-scale-codec",
+ "scale-encode-derive",
+ "scale-info",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd983cf0a9effd76138554ead18a6de542d1af175ac12fd5e91836c5c0268082"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad560913365790f17cbf12479491169f01b9d46d29cfc7422bf8c64bdc61b731"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -646,21 +756,21 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
+checksum = "19df9bd9ace6cc2fe19387c96ce677e823e07d017ceed253e7bb3d1d1bd9c73b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "secp256k1"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -676,22 +786,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -733,6 +843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,14 +866,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "syn"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
  "unicode-xid",
 ]
 
@@ -793,7 +920,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]

--- a/contracts/bulletin_board/Cargo.toml
+++ b/contracts/bulletin_board/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 
-ink = { version = "4.2.0", default-features = false }
+ink = { version = "=4.2.1", default-features = false }
 
 # Following dependncies provide third-party tools (UIs, other clients) with information about how to decode
 # contract types, agnostic of language.

--- a/contracts/bulletin_board/Cargo.toml
+++ b/contracts/bulletin_board/Cargo.toml
@@ -30,12 +30,3 @@ std = [
 ]
 ink-as-dependency = []
 
-# # TODO: Document the followings
-# [profile.dev]
-# codegen-units = 16
-# lto = true
-# 
-# # Number of optimization passes, passed as an argument to `wasm-opt`.
-# # For more information see the output of `cargo contract build --help`.
-# [package.metadata.contract]
-# optimization-passes = "z"

--- a/contracts/bulletin_board/Cargo.toml
+++ b/contracts/bulletin_board/Cargo.toml
@@ -6,24 +6,18 @@ edition = "2021"
 
 [dependencies]
 
-ink = { version = "4.0.0", default-features = false }
+ink = { version = "4.2.0", default-features = false }
 
 # Following dependncies provide third-party tools (UIs, other clients) with information about how to decode
 # contract types, agnostic of language.
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 
 highlighted_posts = { path = "../highlighted_posts", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]
 name = "bulletin_board"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation and for unit test.
-    "rlib",
-]
 
 [features]
 default = ["std"]
@@ -36,12 +30,12 @@ std = [
 ]
 ink-as-dependency = []
 
-# TODO: Document the followings
-[profile.dev]
-codegen-units = 16
-lto = true
-
-# Number of optimization passes, passed as an argument to `wasm-opt`.
-# For more information see the output of `cargo contract build --help`.
-[package.metadata.contract]
-optimization-passes = "z"
+# # TODO: Document the followings
+# [profile.dev]
+# codegen-units = 16
+# lto = true
+# 
+# # Number of optimization passes, passed as an argument to `wasm-opt`.
+# # For more information see the output of `cargo contract build --help`.
+# [package.metadata.contract]
+# optimization-passes = "z"

--- a/contracts/bulletin_board/lib.rs
+++ b/contracts/bulletin_board/lib.rs
@@ -11,7 +11,7 @@
 //! contract - otherwise the calls to `highlight_post` and `delete_highlight`
 //! will fail as the receiving contract will not have the expected endpoint.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 // An entrypoint to all ink! smart contracts.
 // When expanded, this macro will:
@@ -51,7 +51,6 @@ mod bulletin_board {
         prelude::{format, string::String, vec::Vec},
         reflect::ContractEventBase,
         storage::Mapping,
-        ToAccountId,
     };
     /// Errors returned by the contract's methods.
     #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
@@ -142,37 +141,15 @@ mod bulletin_board {
         /// the contract we will instantiate.
         #[ink(constructor)]
         pub fn new(
-            version: u8,
+            _version: u8,
             price_per_block_listing: u128,
-            highlighted_posts_board_hash: Hash,
+            highlighted_posts_board: Option<AccountId>,
         ) -> Self {
-            // The `*Ref` pattern allows for type-safe operation on the
-            // contract. Here, we're constructing an instance of
-            // `HighlightedPosts` contract.
-
-            let highlighted_posts_board_ref = HighlightedPostsRef::new()
-                .code_hash(highlighted_posts_board_hash)
-                .salt_bytes([version.to_le_bytes().as_ref(), Self::env().caller().as_ref()].concat())
-                .endowment(0) /* Amount of value transferred as part of the call. 
-                               * It should not be required but the API of `*Ref` pattern 
-                               * does not allow for calling `instantiate()` 
-                               * on a builder where `endowment` is not set.*/
-                .instantiate();
-
-            // We're mapping back to the `AccountId` so that we can use it in
-            // the `highlight_post` method down below.
-            let highlighted_posts_board =
-                <HighlightedPostsRef as ToAccountId<
-                    super::bulletin_board::Environment,
-                >>::to_account_id(&highlighted_posts_board_ref);
-
-            // This call is required in order to correctly initialize the
-            // `Mapping`s of our contract.
             Self {
                 id_counter: 0,
                 price_per_block_listing: price_per_block_listing,
                 elements_count: 0,
-                highlighted_posts_board: Some(highlighted_posts_board),
+                highlighted_posts_board: highlighted_posts_board,
                 post_authors: Vec::new(),
                 bulletin_map: Mapping::default(),
                 id_map: Mapping::default(),

--- a/contracts/highlighted_posts/Cargo.lock
+++ b/contracts/highlighted_posts/Cargo.lock
@@ -109,6 +109,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,7 +151,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -171,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,14 +280,14 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "ink"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b81ae699fab87b67c4312430e234c1e5b99533aa830dab16cddc9da65cd7a"
+checksum = "311a988dada2242dc748834b86f330bb37ff25482ceef8767104f512a3c465a7"
 dependencies = [
  "derive_more",
  "ink_env",
@@ -254,18 +301,18 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121758652007d56209c7f79af5cc8562b7e869df7ebb72456da79f2a9e72aeea"
+checksum = "5cb3178f207f6a37c3512142c8c6c2561a2aac61d60baa934d08d1e55a67d4a8"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_codegen"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da21ea8189beef99f92fcea3f07018e3278a0e084b86705d3b5e58c3ee38645"
+checksum = "f0b22c0517e5c249d7997cb20e7bd6fbf2076708d39e7b114465c2cb9c1d5c9c"
 dependencies = [
  "blake2",
  "derive_more",
@@ -282,14 +329,14 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "ink_engine"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ec97173506ba6f3cf966a42c0d5f776c2ef843da15854fa1f57d23d2be4ee4"
+checksum = "3c9abc50b932893113e782761ac719c46214ecd10c423a3f626dce30a0c61b45"
 dependencies = [
  "blake2",
  "derive_more",
@@ -302,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639a8172a9911fc6f7384623d25ff6f0834d48b16f5c21e4b0eb656b3de1f877"
+checksum = "aef653137381ff5f37ce2ff9130d11dd1b25f6e9734d97d687c3b953dee4d14f"
 dependencies = [
  "arrayref",
  "blake2",
@@ -312,7 +359,6 @@ dependencies = [
  "derive_more",
  "ink_allocator",
  "ink_engine",
- "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "ink_storage_traits",
@@ -320,6 +366,8 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "rlibc",
+ "scale-decode",
+ "scale-encode",
  "scale-info",
  "secp256k1",
  "sha2",
@@ -329,23 +377,23 @@ dependencies = [
 
 [[package]]
 name = "ink_ir"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aeb30e90744ebf9cce7300a1d013ab91e1b84ebc9887ddabd9b7688c6ac20c1"
+checksum = "1bb9a2826cae9617d8ed2d547ed6e595deb334c1b69ff0a579abd86a76e48c30"
 dependencies = [
  "blake2",
  "either",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "ink_macro"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968f443cf4f177c2cc9d147e33336de19700c8f7e01a6ad5942d9a324e9d3a6c"
+checksum = "c0399b6423e892efb4d39eb76ed9286e4e93fab8141f89b4f4348ee77065b81d"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -353,15 +401,15 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "synstructure",
 ]
 
 [[package]]
 name = "ink_metadata"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8bb193f81ddda8329568ae05786e12a901ea1684c444f780440ecac2bd57b1"
+checksum = "d5fb2b5ad83f725a6d0c8886ca737964d0013a193ca2d21c7e514fd427672416"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -373,31 +421,33 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050dcae91877df7def5fe4426df22c35d116bb24560e3e40d5650b09c7854061"
+checksum = "6a6f174d742ff929abe66716ad8159f324441b4ff5161a3b0e282f416afbbac1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_primitives"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55850e661a97f3158fad3309e0188d6f2dcd5fc7de4c19b969c4c66988886f21"
+checksum = "14b4e4772e1b9384233103c1f488df9854d24b3c16168bcf23613b7d98fb363f"
 dependencies = [
  "derive_more",
  "ink_prelude",
  "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
  "scale-info",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "ink_storage"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f376d6fd2137ea2a42a9f08a83b29e309862a020a0841c0cb9a78c40f1e2e6e5"
+checksum = "9a0f0858c90d5660dc6ec76d31388919a9609aab74723262ccf893d81aafd06c"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -413,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1ff58a3db0bb76b92981236172a3c4d02823996354006f07032e0d3b091024"
+checksum = "a4179f00b052e5955ab7535c1a69042a468771217e9db6a12de2cdbfcb03c861"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
@@ -532,7 +582,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -554,18 +604,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -620,10 +670,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
-name = "scale-info"
-version = "2.3.1"
+name = "scale-bits"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
+checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e5527e4b3bf079d4c0b2f253418598c380722ba37ef20fac9088081407f2b6"
+dependencies = [
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-decode-derive",
+ "scale-info",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-decode-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38741b2f78e4391b94eac6b102af0f6ea2b0f7fe65adb55d7f4004f507854db"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15546e5efbb45f0fc2291f7e202dee8623274c5d8bbfdf9c6886cc8b44a7ced3"
+dependencies = [
+ "parity-scale-codec",
+ "scale-encode-derive",
+ "scale-info",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd983cf0a9effd76138554ead18a6de542d1af175ac12fd5e91836c5c0268082"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad560913365790f17cbf12479491169f01b9d46d29cfc7422bf8c64bdc61b731"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -635,14 +746,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
+checksum = "19df9bd9ace6cc2fe19387c96ce677e823e07d017ceed253e7bb3d1d1bd9c73b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -680,7 +791,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -722,6 +833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,14 +856,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "syn"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
  "unicode-xid",
 ]
 
@@ -782,7 +910,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]

--- a/contracts/highlighted_posts/Cargo.toml
+++ b/contracts/highlighted_posts/Cargo.toml
@@ -7,20 +7,14 @@ edition = "2021"
 [dependencies]
 # OpenBrush-compatible.
 # See https://github.com/727-Ventures/openbrush-contracts/releases/tag/3.0.0-beta for details.
-ink = { version = "4.0.0", default-features = false}
+ink = { version = "4.2.0", default-features = false}
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "highlighted_posts"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation and for unit test.
-    "rlib",
-]
 
 [features]
 default = ["std"]
@@ -31,12 +25,12 @@ std = [
 ]
 ink-as-dependency = []
 
-# TODO: Document the followings
-[profile.dev]
-codegen-units = 16
-lto = true
-
-# Number of optimization passes, passed as an argument to `wasm-opt`.
-# For more information see the output of `cargo contract build --help`.
-[package.metadata.contract]
-optimization-passes = "z"
+# # TODO: Document the followings
+# [profile.dev]
+# codegen-units = 16
+# lto = true
+# 
+# # Number of optimization passes, passed as an argument to `wasm-opt`.
+# # For more information see the output of `cargo contract build --help`.
+# [package.metadata.contract]
+# optimization-passes = "z"

--- a/contracts/highlighted_posts/Cargo.toml
+++ b/contracts/highlighted_posts/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.2.0", default-features = false}
+ink = { version = "=4.2.1", default-features = false}
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }

--- a/contracts/highlighted_posts/Cargo.toml
+++ b/contracts/highlighted_posts/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-# OpenBrush-compatible.
-# See https://github.com/727-Ventures/openbrush-contracts/releases/tag/3.0.0-beta for details.
 ink = { version = "4.2.0", default-features = false}
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
@@ -25,12 +23,3 @@ std = [
 ]
 ink-as-dependency = []
 
-# # TODO: Document the followings
-# [profile.dev]
-# codegen-units = 16
-# lto = true
-# 
-# # Number of optimization passes, passed as an argument to `wasm-opt`.
-# # For more information see the output of `cargo contract build --help`.
-# [package.metadata.contract]
-# optimization-passes = "z"

--- a/contracts/highlighted_posts/lib.rs
+++ b/contracts/highlighted_posts/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub use highlighted_posts::{
     HighlightedPostsError, HighlightedPostsRef, DELETE_HIGHLIGHT_SELECTOR,
@@ -53,7 +53,7 @@ mod highlighted_posts {
 
     impl HighlightedPosts {
         /// Constructor that initializes the contract with empty map.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new() -> Self {
             let caller = Self::env().caller();
             Self {

--- a/contracts/highlighted_posts/lib.rs
+++ b/contracts/highlighted_posts/lib.rs
@@ -53,7 +53,7 @@ mod highlighted_posts {
 
     impl HighlightedPosts {
         /// Constructor that initializes the contract with empty map.
-        #[ink(constructor, payable)]
+        #[ink(constructor)]
         pub fn new() -> Self {
             let caller = Self::env().caller();
             Self {

--- a/frontend/src/metadata/addresses.json
+++ b/frontend/src/metadata/addresses.json
@@ -1,6 +1,6 @@
 {
-  "bulletin_board_code_hash": "0xabd377809605406c97a7051746a9c325928ba86237855121f95324e13723a72d",
-  "highlighted_posts_code_hash": "0x3c0bc6b3e3af029784479f1ec3957c3c3f05cfe963c281137520b8591530674d",
-  "bulletin_board_address": "5H1mMPJzZpzSwwBQCoLi4v7QwY3dvuZYUTyMQBsVwFPtNNpv",
-  "highlighted_posts_address": "5EwpNJ9ADKpMEZub6rYPVgisG8cRnLZjuJ6mYzSKY4X5qkXg"
+  "bulletin_board_code_hash": "",
+  "highlighted_posts_code_hash": "",
+  "bulletin_board_address": "",
+  "highlighted_posts_address": ""
 }

--- a/frontend/src/metadata/addresses.json
+++ b/frontend/src/metadata/addresses.json
@@ -1,4 +1,6 @@
 {
-  "bulletin_board": "",
-  "highlighted_posts": ""
+  "bulletin_board_code_hash": "0xabd377809605406c97a7051746a9c325928ba86237855121f95324e13723a72d",
+  "highlighted_posts_code_hash": "0x3c0bc6b3e3af029784479f1ec3957c3c3f05cfe963c281137520b8591530674d",
+  "bulletin_board_address": "5H1mMPJzZpzSwwBQCoLi4v7QwY3dvuZYUTyMQBsVwFPtNNpv",
+  "highlighted_posts_address": "5EwpNJ9ADKpMEZub6rYPVgisG8cRnLZjuJ6mYzSKY4X5qkXg"
 }

--- a/scripts/addresses.json
+++ b/scripts/addresses.json
@@ -1,6 +1,6 @@
 {
-  "bulletin_board_code_hash": "0xabd377809605406c97a7051746a9c325928ba86237855121f95324e13723a72d",
-  "highlighted_posts_code_hash": "0x3c0bc6b3e3af029784479f1ec3957c3c3f05cfe963c281137520b8591530674d",
-  "bulletin_board_address": "5H1mMPJzZpzSwwBQCoLi4v7QwY3dvuZYUTyMQBsVwFPtNNpv",
-  "highlighted_posts_address": "5EwpNJ9ADKpMEZub6rYPVgisG8cRnLZjuJ6mYzSKY4X5qkXg"
+  "bulletin_board_code_hash": "",
+  "highlighted_posts_code_hash": "",
+  "bulletin_board_address": "",
+  "highlighted_posts_address": ""
 }

--- a/scripts/addresses.json
+++ b/scripts/addresses.json
@@ -1,6 +1,6 @@
 {
-    "bulletin_board_code_hash" : "",
-    "highlighted_posts_code_hash": "",
-    "bulletin_board_address": "",
-    "highlighted_posts_address": ""
+  "bulletin_board_code_hash": "0xabd377809605406c97a7051746a9c325928ba86237855121f95324e13723a72d",
+  "highlighted_posts_code_hash": "0x3c0bc6b3e3af029784479f1ec3957c3c3f05cfe963c281137520b8591530674d",
+  "bulletin_board_address": "5H1mMPJzZpzSwwBQCoLi4v7QwY3dvuZYUTyMQBsVwFPtNNpv",
+  "highlighted_posts_address": "5EwpNJ9ADKpMEZub6rYPVgisG8cRnLZjuJ6mYzSKY4X5qkXg"
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -63,28 +63,20 @@ echo "Highlighted Posts code hash: ${HIGHLIGHTED_POSTS_CODE_HASH}"
 
 # --- instantiate contracts
 
-pushd ${CONTRACTS_PATH}/bulletin_board
+pushd ${CONTRACTS_PATH}
 
-# Using temporary file as piping JSON from env variable crates problems with escaping.
-temp_file=$(mktemp)
-# Remove temporary file when finished.
-trap "rm -f $temp_file" 0 2 3 15 
+echo "Instantiating Highlighted Posts contract"
+HIGHLIGHTED_POSTS_WASM_FILE="highlighted_posts/target/ink/highlighted_posts.contract"
+HIGHLIGHTED_POSTS_ADDRESS=$(cargo contract instantiate --url "$NODE_URL" --salt 48 --suri "$AUTHORITY_SEED" ${HIGHLIGHTED_POSTS_WASM_FILE} --constructor new --execute --skip-confirm | tail -n 1)
+HIGHLIGHTED_POSTS_ADDRESS=${HIGHLIGHTED_POSTS_ADDRESS: -48}
 
 echo "Instantiating Bulletin Board contract"
-cargo contract instantiate --url "$NODE_URL" --suri "$AUTHORITY_SEED" --code-hash $BULLETIN_BOARD_CODE_HASH --constructor new --args "0" "10" $HIGHLIGHTED_POSTS_CODE_HASH --skip-confirm --output-json > temp_file
+BULLETIN_BOARD_WASM_FILE="bulletin_board/target/ink/bulletin_board.contract"
+BULLETIN_BOARD_ADDRESS=$(cargo contract instantiate --url "$NODE_URL" --salt 48 --suri "$AUTHORITY_SEED" ${BULLETIN_BOARD_WASM_FILE} --constructor new --args "0" "10" "Some(\"${HIGHLIGHTED_POSTS_ADDRESS}\")" --execute --skip-confirm | tail -n 1)
+BULLETIN_BOARD_ADDRESS=${BULLETIN_BOARD_ADDRESS: -48}
 
-# We're initializing `highlighted_posts` contract in the constructor of `bulletin board`
-# so there will be multiple new contract addresses. `cargo contract` outputs the first one
-# from the list but that will be the last contract instantiated and the Bulletin Board contract address is the last one on that list.
-BULLETIN_BOARD_ADDRESS=$(cat temp_file | jq  '.events[] | select((.pallet == "Contracts") and (.name = "Instantiated")) | .fields[] | select(.name == "contract") | .value.Literal' | tail -1 | tr -d '"')
 if [[ -z BULLETIN_BOARD_ADDRESS && -v BULLETIN_BOARD_ADDRESS ]]; then
     echo "Empty BULLETIN_BOARD_ADDRESS"
-    exit 1
-fi
-
-HIGHLIGHTED_POSTS_ADDRESS=$(cat temp_file | jq  '.events[] | select((.pallet == "Contracts") and (.name = "Instantiated")) | .fields[] | select(.name == "contract") | .value.Literal' | head -1 | tr -d '"')
-if [[ -z HIGHLIGHTED_POSTS_ADDRESS && -v HIGHLIGHTED_POSTS_ADDRESS ]]; then
-    echo "Empty HIGHLIGHTED_POSTS_ADDDRESS"
     exit 1
 fi
 

--- a/scripts/update_contract_metadata.sh
+++ b/scripts/update_contract_metadata.sh
@@ -10,8 +10,8 @@ METADATA_FILE=/target/ink/metadata.json
 BULLETIN_BOARD_METADATA=$(pwd)/frontend/src/metadata/metadata_bulletin_board.json
 HIGHLIHTED_POSTS_METADATA=$(pwd)/frontend/src/metadata/metadata_highlighted_posts.json
 
-cp ${CONTRACTS_PATH}/bulletin_board${METADATA_FILE} ${BULLETIN_BOARD_METADATA}
-cp ${CONTRACTS_PATH}/highlighted_posts${METADATA_FILE} ${HIGHLIHTED_POSTS_METADATA}
+cp ${CONTRACTS_PATH}/bulletin_board/target/ink/bulletin_board.json ${BULLETIN_BOARD_METADATA}
+cp ${CONTRACTS_PATH}/highlighted_posts/target/ink/highlighted_posts.json ${HIGHLIHTED_POSTS_METADATA}
 
 echo "Contract metadata updated"
 exit 0


### PR DESCRIPTION
At the heart of the fix is passing the `--execute` flag to `cargo contract` calls. Otherwise it just performs a dry-run which leaves things in a slightly confusing state.

Additionally, the code has been adapted to work with `cargo-contract 3.0.1` and `ink 4.2.0`.
FWIW, I am building this using Rust 1.69 with `nightly-2023-02-07` and running on `substrate-contracts-node` v0.26.

Additionallier, turns our if you revert the build order inside `contracts/Makefile`, the `highlighted_posts` contract ends up being compiled once (as opposed to twice as previously) :)